### PR TITLE
feat: add model definitions and naming code

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,15 @@ bun install
 To run tests:
 
 ```
-bun test
+bun test:all # Runs `bun test` with NODE_ENV=development and then NODE_ENV=production
+bun test:dev # Runs `bun test` with NODE_ENV=development
+bun test:prod # Runs `bun test` with NODE_ENV=production
 ```
 
 To build:
 
 ```
-bun run build.ts
+bun run build
 ```
 
 This project was created using `bun init` in bun v1.0.4. [Bun](https://bun.sh) is a fast all-in-one JavaScript runtime.

--- a/package.json
+++ b/package.json
@@ -10,5 +10,11 @@
   },
   "peerDependencies": {
     "mobx": "^6.11.0"
+  },
+  "scripts": {
+    "build": "bun ./build.ts",
+    "test:all": "NODE_ENV=development bun test && NODE_ENV=production bun test",
+    "test:dev": "NODE_ENV=development bun test",
+    "test:prod": "NODE_ENV=production bun test"
   }
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { t } from "./index.ts";
+import { t, types } from "./index.ts";
 
 describe("top level exports", () => {
   test("should include t", () => {
     expect(t).toBeDefined();
+  });
+  // This is for compatibility with MST before 5.4.0, which most people and documentation use as of November 2023.
+  test("should alias `t` as `types`", () => {
+    expect(types).toBeDefined();
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,3 @@
-export const t = () => "To be implemented!";
+import { t } from "./t";
+
+export { t, t as types };

--- a/src/t.test.ts
+++ b/src/t.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, test } from "bun:test";
+import { t } from "./t";
+
+describe("t", () => {
+  it("should be defined", () => {
+    expect(t).toBeDefined();
+  });
+  describe("Model instantiation", () => {
+    describe("Model name", () => {
+      test("Providing a string as the first argument should set it as the model's name.", () => {
+        const Model = t.model("Name", {});
+
+        expect(Model.name).toBe("Name");
+      });
+      test("Providing an empty string as the first argument should set it as the model's name.", () => {
+        const Model = t.model("", {});
+
+        expect(Model.name).toBe("");
+      });
+      describe("Providing a non-string argument as the first and only argument should set the model's name as 'AnonymousModel'.", () => {
+        const testCases = [
+          {},
+          null,
+          undefined,
+          1,
+          true,
+          [],
+          function () {},
+          new Date(),
+          /a/,
+          new Map(),
+          new Set(),
+          Symbol(),
+          new Error(),
+          NaN,
+          Infinity,
+        ];
+
+        testCases.forEach((testCase) => {
+          test(`Providing ${JSON.stringify(
+            testCase
+          )} as the first argument should set the model's name as 'AnonymousModel'.`, () => {
+            const Model = t.model(testCase as any);
+
+            expect(Model.name).toBe("AnonymousModel");
+          });
+        });
+      });
+
+      if (process.env.NODE_ENV !== "production") {
+        describe("Providing a non-string argument as the first argument, and any other argument as the second argument", () => {
+          describe("should throw an error in development mode", () => {
+            const testCases = [
+              {},
+              null,
+              undefined,
+              1,
+              true,
+              [],
+              function () {},
+              new Date(),
+              /a/,
+              new Map(),
+              new Set(),
+              Symbol(),
+              new Error(),
+              NaN,
+              Infinity,
+            ];
+
+            testCases.forEach((testCase) => {
+              test(`Providing ${JSON.stringify(
+                testCase
+              )} as the first argument should throw an error.`, () => {
+                expect(() => {
+                  t.model(testCase as any, {});
+                }).toThrow();
+              });
+            });
+          });
+        });
+      } else {
+        describe("Providing a non-string argument as the first argument, and any other argument as the second argument", () => {
+          describe("should not throw an error in production mode", () => {
+            const testCases = [
+              {},
+              null,
+              undefined,
+              1,
+              true,
+              [],
+              function () {},
+              new Date(),
+              /a/,
+              new Map(),
+              new Set(),
+              Symbol(),
+              new Error(),
+              NaN,
+              Infinity,
+            ];
+
+            testCases.forEach((testCase) => {
+              test(`Providing ${JSON.stringify(
+                testCase
+              )} as the first argument should not throw an error.`, () => {
+                expect(() => {
+                  t.model(testCase as any, {});
+                }).not.toThrow();
+              });
+            });
+          });
+        });
+      }
+    });
+  });
+});

--- a/src/t.ts
+++ b/src/t.ts
@@ -1,0 +1,52 @@
+/**
+ * @internal
+ * @hidden
+ */
+export function devMode() {
+  return process.env.NODE_ENV !== "production";
+}
+
+/**
+ * @internal
+ * @hidden
+ */
+export function fail(message = "Illegal state"): Error {
+  return new Error("[mobx-forge] " + message);
+}
+
+interface IModelType {
+  name?: string;
+  properties: any;
+}
+
+interface IModelTypeArguments {
+  name?: string;
+  properties: any;
+}
+
+class ModelType implements IModelType {
+  name?: string | undefined;
+  properties: any;
+
+  constructor(args: IModelTypeArguments) {
+    const { name, properties } = args;
+    this.name = name;
+    this.properties = properties;
+  }
+}
+
+const model = (...args: any[]): IModelType => {
+  if (devMode() && typeof args[0] !== "string" && args[1]) {
+    throw fail(
+      "Model creation failed. First argument must be a string when two arguments are provided"
+    );
+  }
+
+  const name = typeof args[0] === "string" ? args.shift() : "AnonymousModel";
+  const properties = args.shift() || {};
+  return new ModelType({ name, properties });
+};
+
+export const t = {
+  model,
+};


### PR DESCRIPTION
@jamonholmgren - when we spoke on Slack, I said I'd probably start with defining primitives first, and then building out the complex types.

But I spent an hour or two trying to implement just `types.string`, and I hit a few challenges:

1. There's no ergonomic way to use or test `types.string`. Technically you can call `types.string.create()`, but it's just kind of funky. People don't usually do that in MST. The primitive types tend to be included and referenced in model definitions.
2. There are so many TypeScript and JavaScript abstractions going on under the hood just for any basic MST type that I couldn't successfully reproduce `types.string` functionality without basically re-writing or copy/pasting thousands of lines of MST code. I tried to ignore deprecated/unnecessary interfaces and classes, but everything is so tightly intertwined I couldn't get anything to run even after a few hours of copy pasting/writing.

So I thought back to my [blog post about defining a `types.model`](https://coolsoftware.dev/blog/what-happens-when-you-create-an-mst-model/). I think a better approach to this new library is to start from the outside-in on complex types.

This PR adds `t.model`, which is a function that will take any set of arguments, and try to return an instance of a `ModelType` class.

I pulled in the naming tests from MST, and wrote functionality that makes sure the naming of our `t.model` behaves interchangeably to MST's `t.model`.

I think emulating top-level functionality like that will allow me to more faithfully reproduce MST without having to directly fork it (which I'm still willing to do, but I want to try a few weeks of this approach), and we can devise our own level of abstractions, rather than using the existing MST abstractions to build up a new library.

Also added a `scripts` block to run some common scripts, updated README, and pulled in some utilities like `devMode` and `fail`. I expect to move those to their own place later, but I want to start with the simplest file structure possible.