### PR TITLE
feat: pass MST t.number tests

### DIFF
--- a/src/NumberPrimitive.ts
+++ b/src/NumberPrimitive.ts
@@ -1,0 +1,88 @@
+import { createScalarNode } from "./ScalarNode";
+import { TypeFlags } from "./utilities";
+import { getStateTreeNodeSafe } from "./state/state-utiltities";
+import {
+  getType,
+  typeCheckSuccess,
+  typeCheckFailure,
+} from "./types/type-utilities";
+
+export class NumberPrimitive {
+  readonly flags: TypeFlags = TypeFlags.Number;
+  readonly isType = true;
+  readonly name = "number";
+
+  describe() {
+    return "number";
+  }
+  create(snapshot?: any, environment?: any) {
+    // TODO: implement actual type checking. For now, we just assume we're looking for numbers
+    if (typeof snapshot !== "number") {
+      throw new Error("Expected number");
+    }
+    return this.instantiate(null, "", environment, snapshot).value;
+  }
+
+  createNewInstance(snapshot: any): any {
+    return snapshot as any;
+  }
+
+  instantiate(
+    parent: any | null,
+    subpath: string,
+    environment: any,
+    initialValue: any
+  ): any {
+    return createScalarNode(this, parent, subpath, environment, initialValue);
+  }
+
+  getValue(node: any): any {
+    // if we ever find a case where scalar nodes can be accessed without iterating through its parent
+    // uncomment this to make sure the parent chain is created when this is accessed
+    // if (node.parent) {
+    //     node.parent.createObservableInstanceIfNeeded()
+    // }
+    return node.storedValue;
+  }
+
+  getSnapshot(node: any): any {
+    return node.storedValue;
+  }
+
+  getSubTypes(): null {
+    return null;
+  }
+
+  checker(value: any): boolean {
+    return typeof value === "number";
+  }
+
+  isValidSnapshot(value: any, context: any): any {
+    if (this.checker(value as any)) {
+      return typeCheckSuccess();
+    }
+
+    return typeCheckFailure(context, value, `Value is not a ${this.name}`);
+  }
+
+  isAssignableFrom(type: any): boolean {
+    return type === this;
+  }
+
+  validate(value: any, context: any): any {
+    const node = getStateTreeNodeSafe(value);
+    if (node) {
+      const valueType = getType(value);
+      return this.isAssignableFrom(valueType)
+        ? typeCheckSuccess()
+        : typeCheckFailure(context, value);
+      // it is tempting to compare snapshots, but in that case we should always clone on assignments...
+    }
+    return this.isValidSnapshot(value, context);
+  }
+
+  is(thing: any): thing is any {
+    debugger;
+    return this.validate(thing, [{ path: "", type: this }]).length === 0;
+  }
+}

--- a/src/t.test.ts
+++ b/src/t.test.ts
@@ -331,4 +331,325 @@ describe("t", () => {
       });
     });
   });
+
+  describe("t.number", () => {
+    describe("methods", () => {
+      describe("create", () => {
+        describe("with no arguments", () => {
+          if (process.env.NODE_ENV !== "production") {
+            it("should throw an error in development", () => {
+              expect(() => {
+                t.number.create();
+              }).toThrow();
+            });
+          }
+        });
+        describe("with a number argument", () => {
+          it("should return a number", () => {
+            const n = t.number.create(1);
+            expect(typeof n).toBe("number");
+          });
+        });
+        describe("with argument of different types", () => {
+          // Keep in mind, Infinity and NaN are treated as numbers in JavaScript, so we won't test for them here.
+          const testCases = [
+            null,
+            undefined,
+            "string",
+            true,
+            [],
+            function () {},
+            new Date(),
+            /a/,
+            new Map(),
+            new Set(),
+            Symbol(),
+            new Error(),
+          ];
+
+          if (process.env.NODE_ENV !== "production") {
+            testCases.forEach((testCase) => {
+              it(`should throw an error when passed ${JSON.stringify(
+                testCase
+              )}`, () => {
+                expect(() => {
+                  t.number.create(testCase as any);
+                }).toThrow();
+              });
+            });
+          }
+        });
+      });
+      describe("describe", () => {
+        it("should return the value 'number'", () => {
+          const description = t.number.describe();
+          expect(description).toBe("number");
+        });
+      });
+      describe("getSnapshot", () => {
+        it("should return the value passed in", () => {
+          const n = t.number.instantiate(null, "", {}, 1);
+          const snapshot = t.number.getSnapshot(n);
+          expect(snapshot).toBe(1);
+        });
+      });
+      describe("getSubtype", () => {
+        it("should return null", () => {
+          const subtype = t.number.getSubTypes();
+          expect(subtype).toBe(null);
+        });
+      });
+      describe("instantiate", () => {
+        if (process.env.NODE_ENV !== "production") {
+          describe("with invalid arguments", () => {
+            it("should not throw an error", () => {
+              expect(() => {
+                // @ts-ignore
+                t.number.instantiate();
+              }).not.toThrow();
+            });
+          });
+        }
+        describe("with a string argument", () => {
+          it("should return an object", () => {
+            const n = t.number.instantiate(null, "", {}, 1);
+            expect(typeof n).toBe("object");
+          });
+        });
+      });
+      describe("is", () => {
+        describe("with a number argument", () => {
+          it("should return true", () => {
+            const result = t.number.is(1);
+            expect(result).toBe(true);
+          });
+        });
+        describe("with argument of different types", () => {
+          // Keep in mind, Infinity and NaN are treated as numbers in JavaScript, so we won't test for them here.
+          const testCases = [
+            null,
+            undefined,
+            "string",
+            true,
+            [],
+            function () {},
+            new Date(),
+            /a/,
+            new Map(),
+            new Set(),
+            Symbol(),
+            new Error(),
+          ];
+
+          testCases.forEach((testCase) => {
+            it(`should return false when passed ${JSON.stringify(
+              testCase
+            )}`, () => {
+              const result = t.number.is(testCase as any);
+              expect(result).toBe(false);
+            });
+          });
+        });
+      });
+      describe("isAssignableFrom", () => {
+        describe("with a number argument", () => {
+          it("should return true", () => {
+            const result = t.number.isAssignableFrom(t.number);
+            expect(result).toBe(true);
+          });
+        });
+        describe("with argument of different types", () => {
+          const testCases = [
+            t.Date,
+            t.boolean,
+            t.finite,
+            t.float,
+            t.identifier,
+            t.identifierNumber,
+            t.integer,
+            t.null,
+            t.string,
+            t.undefined,
+          ];
+
+          testCases.forEach((testCase) => {
+            it(`should return false when passed ${JSON.stringify(
+              testCase
+            )}`, () => {
+              const result = t.number.isAssignableFrom(testCase as any);
+              expect(result).toBe(false);
+            });
+          });
+        });
+      });
+      // TODO: we need to test this, but to be honest I'm not sure what the expected behavior is on single string noden.
+      describe.skip("reconcile", () => {});
+      describe("validate", () => {
+        describe("with a string argument", () => {
+          it("should return with no validation errors", () => {
+            const result = t.number.validate(1, []);
+            expect(result).toEqual([]);
+          });
+        });
+        describe("with argument of different types", () => {
+          // Keep in mind, Infinity and NaN are treated as numbers in JavaScript, so we won't test for them here.
+          const testCases = [
+            null,
+            undefined,
+            "string",
+            true,
+            [],
+            function () {},
+            new Date(),
+            /a/,
+            new Map(),
+            new Set(),
+            Symbol(),
+            new Error(),
+          ];
+
+          testCases.forEach((testCase) => {
+            it(`should return with a validation error when passed ${JSON.stringify(
+              testCase
+            )}`, () => {
+              const result = t.number.validate(testCase as any, []);
+              expect(result).toEqual([
+                {
+                  context: [],
+                  message: "Value is not a number",
+                  value: testCase,
+                },
+              ]);
+            });
+          });
+        });
+      });
+    });
+    describe("properties", () => {
+      describe("flags", () => {
+        test("return the correct value", () => {
+          const flags = t.number.flags;
+          expect(flags).toBe(2);
+        });
+      });
+      describe("identifierAttribute", () => {
+        // We don't have a way to set the identifierAttribute on a primitive type, so this should return undefined.
+        test("returns undefined", () => {
+          const identifierAttribute = t.number.identifierAttribute;
+          expect(identifierAttribute).toBe(undefined);
+        });
+      });
+      describe("isType", () => {
+        test("returns true", () => {
+          const isType = t.number.isType;
+          expect(isType).toBe(true);
+        });
+      });
+      describe("name", () => {
+        test('returns "number"', () => {
+          const name = t.number.name;
+          expect(name).toBe("number");
+        });
+      });
+    });
+    describe("instance", () => {
+      describe("methods", () => {
+        describe("aboutToDie", () => {
+          it("calls the beforeDetach hook", () => {
+            const n = t.number.instantiate(null, "", {}, 1);
+            let called = false;
+            n.registerHook(Hook.beforeDestroy, () => {
+              called = true;
+            });
+            n.aboutToDie();
+            expect(called).toBe(true);
+          });
+        });
+        describe("die", () => {
+          it("kills the node", () => {
+            const n = t.number.instantiate(null, "", {}, 1);
+            n.die();
+            expect(n.isAlive).toBe(false);
+          });
+          it("should mark the node as dead", () => {
+            const n = t.number.instantiate(null, "", {}, 1);
+            n.die();
+            expect(n.state).toBe(NodeLifeCycle.DEAD);
+          });
+        });
+        describe("finalizeCreation", () => {
+          it("should mark the node as finalized", () => {
+            const n = t.number.instantiate(null, "", {}, 1);
+            n.finalizeCreation();
+            expect(n.state).toBe(NodeLifeCycle.FINALIZED);
+          });
+        });
+        describe("finalizeDeath", () => {
+          it("should mark the node as dead", () => {
+            const n = t.number.instantiate(null, "", {}, 1);
+            n.finalizeDeath();
+            expect(n.state).toBe(NodeLifeCycle.DEAD);
+          });
+        });
+        describe("getReconciliationType", () => {
+          it("should return the correct type", () => {
+            const n = t.number.instantiate(null, "", {}, 1);
+            const type = n.getReconciliationType();
+            expect(type).toBe(t.number);
+          });
+        });
+        describe("getSnapshot", () => {
+          it("should return the value passed in", () => {
+            const n = t.number.instantiate(null, "", {}, 1);
+            const snapshot = n.getSnapshot();
+            expect(snapshot).toBe(1);
+          });
+        });
+        describe("registerHook", () => {
+          it("should register a hook and call it", () => {
+            const n = t.number.instantiate(null, "", {}, 1);
+            let called = false;
+            n.registerHook(Hook.beforeDestroy, () => {
+              called = true;
+            });
+
+            n.die();
+
+            expect(called).toBe(true);
+          });
+        });
+        describe("setParent", () => {
+          if (process.env.NODE_ENV !== "production") {
+            describe("with null", () => {
+              it("should throw an error", () => {
+                const n = t.number.instantiate(null, "", {}, 1);
+                expect(() => {
+                  n.setParent(null, "foo");
+                }).toThrow();
+              });
+            });
+            describe.skip("with a parent object", () => {
+              it("should throw an error", () => {
+                const Parent = t.model({
+                  child: t.number,
+                });
+
+                // @ts-ignore
+                const parent = Parent.create({ child: 1 });
+
+                const n = t.number.instantiate(null, "", {}, 1);
+
+                expect(() => {
+                  // @ts-ignore
+                  n.setParent(parent, "bar");
+                }).toThrow(
+                  "[mobx-state-tree] assertion failed: scalar nodes cannot change their parent"
+                );
+              });
+            });
+          }
+        });
+      });
+    });
+  });
 });

--- a/src/t.ts
+++ b/src/t.ts
@@ -1,7 +1,10 @@
 import { model } from "./model";
 import { StringPrimitive } from "./StringPrimitive";
+import { NumberPrimitive } from "./NumberPrimitive";
 
-export const string: any = new StringPrimitive();
+const string: any = new StringPrimitive();
+
+const number: any = new NumberPrimitive();
 
 export const getSnapshot = (target: any) => {
   return target.snapshot();
@@ -18,6 +21,6 @@ export const t = {
   identifierNumber: null,
   integer: null,
   null: null,
-  number: null,
+  number,
   undefined: null,
 };


### PR DESCRIPTION
This PR adds the mobx-state-tree tests for `t.number`, and passes all of them (except for the one that requires `t.model` to work).

Right now the `NumberPrimitive` class is pretty duplicative of the `StringPrimitive` class. My intention is to [avoid hasty abstractions](https://kentcdodds.com/blog/aha-programming), and write a few primitive classes before figuring out a good abstraction point for them.

It's very likely that I'll end up copying or mostly adapting what already exists in mobx-state-tree, but I want to get there on my own so I can really understand what's going on under the hood.

`bun test:all` should pass.