### PR TITLE
feat: add BooleanPrimitive

### DIFF
--- a/src/BooleanPrimitive.ts
+++ b/src/BooleanPrimitive.ts
@@ -7,18 +7,18 @@ import {
   typeCheckFailure,
 } from "./types/type-utilities";
 
-export class NumberPrimitive {
-  readonly flags: TypeFlags = TypeFlags.Number;
+export class BooleanPrimitive {
+  readonly flags: TypeFlags = TypeFlags.Boolean;
   readonly isType = true;
-  readonly name = "number";
+  readonly name = "boolean";
 
   describe() {
-    return "number";
+    return "boolean";
   }
   create(snapshot?: any, environment?: any) {
     // TODO: implement actual type checking. For now, we just assume we're looking for numbers
-    if (typeof snapshot !== "number") {
-      throw new Error("Expected number");
+    if (typeof snapshot !== "boolean") {
+      throw new Error("Expected boolean");
     }
     return this.instantiate(null, "", environment, snapshot).value;
   }
@@ -54,7 +54,7 @@ export class NumberPrimitive {
   }
 
   checker(value: any): boolean {
-    return typeof value === "number";
+    return typeof value === "boolean";
   }
 
   isValidSnapshot(value: any, context: any): any {

--- a/src/StringPrimitive.ts
+++ b/src/StringPrimitive.ts
@@ -82,7 +82,6 @@ export class StringPrimitive {
   }
 
   is(thing: any): thing is any {
-    debugger;
     return this.validate(thing, [{ path: "", type: this }]).length === 0;
   }
 }

--- a/src/t.test.ts
+++ b/src/t.test.ts
@@ -652,4 +652,328 @@ describe("t", () => {
       });
     });
   });
+
+  describe("t.boolean", () => {
+    describe("methods", () => {
+      describe("create", () => {
+        describe("with no arguments", () => {
+          if (process.env.NODE_ENV !== "production") {
+            it("should throw an error in development", () => {
+              expect(() => {
+                t.boolean.create();
+              }).toThrow();
+            });
+          }
+        });
+        describe("with a boolean argument", () => {
+          it("should return a boolean", () => {
+            const n = t.boolean.create(true);
+            expect(typeof n).toBe("boolean");
+          });
+        });
+        describe("with argument of different types", () => {
+          const testCases = [
+            null,
+            undefined,
+            "string",
+            1,
+            [],
+            function () {},
+            new Date(),
+            /a/,
+            new Map(),
+            new Set(),
+            Symbol(),
+            new Error(),
+            Infinity,
+            NaN,
+          ];
+
+          if (process.env.NODE_ENV !== "production") {
+            testCases.forEach((testCase) => {
+              it(`should throw an error when passed ${JSON.stringify(
+                testCase
+              )}`, () => {
+                expect(() => {
+                  t.boolean.create(testCase as any);
+                }).toThrow();
+              });
+            });
+          }
+        });
+      });
+      describe("describe", () => {
+        it("should return the value 'boolean'", () => {
+          const description = t.boolean.describe();
+          expect(description).toBe("boolean");
+        });
+      });
+      describe("getSnapshot", () => {
+        it("should return the value passed in", () => {
+          const b = t.boolean.instantiate(null, "", {}, true);
+          const snapshot = t.boolean.getSnapshot(b);
+          expect(snapshot).toBe(true);
+        });
+      });
+      describe("getSubtype", () => {
+        it("should return null", () => {
+          const subtype = t.boolean.getSubTypes();
+          expect(subtype).toBe(null);
+        });
+      });
+      describe("instantiate", () => {
+        if (process.env.NODE_ENV !== "production") {
+          describe("with invalid arguments", () => {
+            it("should not throw an error", () => {
+              expect(() => {
+                // @ts-ignore
+                t.boolean.instantiate();
+              }).not.toThrow();
+            });
+          });
+        }
+        describe("with a boolean argument", () => {
+          it("should return an object", () => {
+            const b = t.boolean.instantiate(null, "", {}, true);
+            expect(typeof b).toBe("object");
+          });
+        });
+      });
+      describe("is", () => {
+        describe("with a boolean argument", () => {
+          it("should return true", () => {
+            const result = t.boolean.is(true);
+            expect(result).toBe(true);
+          });
+        });
+        describe("with argument of different types", () => {
+          const testCases = [
+            null,
+            undefined,
+            "string",
+            1,
+            [],
+            function () {},
+            new Date(),
+            /a/,
+            new Map(),
+            new Set(),
+            Symbol(),
+            new Error(),
+            Infinity,
+            NaN,
+          ];
+
+          testCases.forEach((testCase) => {
+            it(`should return false when passed ${JSON.stringify(
+              testCase
+            )}`, () => {
+              const result = t.boolean.is(testCase as any);
+              expect(result).toBe(false);
+            });
+          });
+        });
+      });
+      describe("isAssignableFrom", () => {
+        describe("with a boolean argument", () => {
+          it("should return true", () => {
+            const result = t.boolean.isAssignableFrom(t.boolean);
+            expect(result).toBe(true);
+          });
+        });
+        describe("with argument of different types", () => {
+          const testCases = [
+            t.Date,
+            t.number,
+            t.finite,
+            t.float,
+            t.identifier,
+            t.identifierNumber,
+            t.integer,
+            t.null,
+            t.string,
+            t.undefined,
+          ];
+
+          testCases.forEach((testCase) => {
+            it(`should return false when passed ${JSON.stringify(
+              testCase
+            )}`, () => {
+              const result = t.boolean.isAssignableFrom(testCase as any);
+              expect(result).toBe(false);
+            });
+          });
+        });
+      });
+      // TODO: we need to test this, but to be honest I'm not sure what the expected behavior is on single string noden.
+      describe.skip("reconcile", () => {});
+      describe("validate", () => {
+        describe("with a boolean argument", () => {
+          it("should return with no validation errors", () => {
+            const result = t.boolean.validate(true, []);
+            expect(result).toEqual([]);
+          });
+        });
+        describe("with argument of different types", () => {
+          const testCases = [
+            null,
+            undefined,
+            "string",
+            1,
+            [],
+            function () {},
+            new Date(),
+            /a/,
+            new Map(),
+            new Set(),
+            Symbol(),
+            new Error(),
+            Infinity,
+            NaN,
+          ];
+
+          testCases.forEach((testCase) => {
+            it(`should return with a validation error when passed ${JSON.stringify(
+              testCase
+            )}`, () => {
+              const result = t.boolean.validate(testCase as any, []);
+              expect(result).toEqual([
+                {
+                  context: [],
+                  message: "Value is not a boolean",
+                  value: testCase,
+                },
+              ]);
+            });
+          });
+        });
+      });
+    });
+    describe("properties", () => {
+      describe("flags", () => {
+        test("return the correct value", () => {
+          const flags = t.boolean.flags;
+          expect(flags).toBe(4);
+        });
+      });
+      describe("identifierAttribute", () => {
+        // We don't have a way to set the identifierAttribute on a primitive type, so this should return undefined.
+        test("returns undefined", () => {
+          const identifierAttribute = t.boolean.identifierAttribute;
+          expect(identifierAttribute).toBe(undefined);
+        });
+      });
+      describe("isType", () => {
+        test("returns true", () => {
+          const isType = t.boolean.isType;
+          expect(isType).toBe(true);
+        });
+      });
+      describe("name", () => {
+        test('returns "boolean"', () => {
+          const name = t.boolean.name;
+          expect(name).toBe("boolean");
+        });
+      });
+    });
+    describe("instance", () => {
+      describe("methods", () => {
+        describe("aboutToDie", () => {
+          it("calls the beforeDetach hook", () => {
+            const b = t.boolean.instantiate(null, "", {}, true);
+            let called = false;
+            b.registerHook(Hook.beforeDestroy, () => {
+              called = true;
+            });
+            b.aboutToDie();
+            expect(called).toBe(true);
+          });
+        });
+        describe("die", () => {
+          it("kills the node", () => {
+            const b = t.boolean.instantiate(null, "", {}, true);
+            b.die();
+            expect(b.isAlive).toBe(false);
+          });
+          it("should mark the node as dead", () => {
+            const b = t.boolean.instantiate(null, "", {}, true);
+            b.die();
+            expect(b.state).toBe(NodeLifeCycle.DEAD);
+          });
+        });
+        describe("finalizeCreation", () => {
+          it("should mark the node as finalized", () => {
+            const b = t.boolean.instantiate(null, "", {}, true);
+            b.finalizeCreation();
+            expect(b.state).toBe(NodeLifeCycle.FINALIZED);
+          });
+        });
+        describe("finalizeDeath", () => {
+          it("should mark the node as dead", () => {
+            const b = t.boolean.instantiate(null, "", {}, true);
+            b.finalizeDeath();
+            expect(b.state).toBe(NodeLifeCycle.DEAD);
+          });
+        });
+        describe("getReconciliationType", () => {
+          it("should return the correct type", () => {
+            const b = t.boolean.instantiate(null, "", {}, true);
+            const type = b.getReconciliationType();
+            expect(type).toBe(t.boolean);
+          });
+        });
+        describe("getSnapshot", () => {
+          it("should return the value passed in", () => {
+            const b = t.boolean.instantiate(null, "", {}, true);
+            const snapshot = b.getSnapshot();
+            expect(snapshot).toBe(true);
+          });
+        });
+        describe("registerHook", () => {
+          it("should register a hook and call it", () => {
+            const b = t.boolean.instantiate(null, "", {}, true);
+            let called = false;
+            b.registerHook(Hook.beforeDestroy, () => {
+              called = true;
+            });
+
+            b.die();
+
+            expect(called).toBe(true);
+          });
+        });
+        describe("setParent", () => {
+          if (process.env.NODE_ENV !== "production") {
+            describe("with null", () => {
+              it("should throw an error", () => {
+                const b = t.boolean.instantiate(null, "", {}, true);
+                expect(() => {
+                  b.setParent(null, "foo");
+                }).toThrow();
+              });
+            });
+            describe.skip("with a parent object", () => {
+              it("should throw an error", () => {
+                const Parent = t.model({
+                  child: t.boolean,
+                });
+
+                // @ts-ignore
+                const parent = Parent.create({ child: true });
+
+                const b = t.boolean.instantiate(null, "", {}, true);
+
+                expect(() => {
+                  // @ts-ignore
+                  b.setParent(parent, "bar");
+                }).toThrow(
+                  "[mobx-state-tree] assertion failed: scalar nodes cannot change their parent"
+                );
+              });
+            });
+          }
+        });
+      });
+    });
+  });
 });

--- a/src/t.ts
+++ b/src/t.ts
@@ -1,10 +1,13 @@
 import { model } from "./model";
 import { StringPrimitive } from "./StringPrimitive";
 import { NumberPrimitive } from "./NumberPrimitive";
+import { BooleanPrimitive } from "./BooleanPrimitive";
 
 const string: any = new StringPrimitive();
 
 const number: any = new NumberPrimitive();
+
+const boolean: any = new BooleanPrimitive();
 
 export const getSnapshot = (target: any) => {
   return target.snapshot();
@@ -14,7 +17,7 @@ export const t = {
   model,
   string,
   Date: null,
-  boolean: null,
+  boolean,
   finite: null,
   float: null,
   identifier: null,


### PR DESCRIPTION
Much like #5 and #4, but for `t.boolean`. Passes all of the existing MST `t.boolean` tests.

I'm probably going to do the Date primitive and then look to see where I can pull these classes together into something a little more abstract.

`bun test:all` should pass here.