### PR TITLE
feat: add t.Date primitive

### DIFF
--- a/src/DatePrimitive.ts
+++ b/src/DatePrimitive.ts
@@ -1,0 +1,94 @@
+import { createScalarNode } from "./ScalarNode";
+import { TypeFlags } from "./utilities";
+import { getStateTreeNodeSafe } from "./state/state-utiltities";
+import {
+  getType,
+  typeCheckSuccess,
+  typeCheckFailure,
+} from "./types/type-utilities";
+
+export class DatePrimitive {
+  readonly flags: TypeFlags = TypeFlags.Date;
+  readonly isType = true;
+  readonly name = "Date";
+
+  describe() {
+    return "Date";
+  }
+  create(snapshot?: any, environment?: any) {
+    // Check if the snapshot is a Date or a unix milliseconds timestamp
+    if (!(snapshot instanceof Date) && typeof snapshot !== "number") {
+      throw new Error("Expected Date or unix milliseconds timestamp");
+    }
+    return this.instantiate(null, "", environment, snapshot).value;
+  }
+
+  createNewInstance(snapshot: any): any {
+    return snapshot as any;
+  }
+
+  instantiate(
+    parent: any | null,
+    subpath: string,
+    environment: any,
+    initialValue: any
+  ): any {
+    return createScalarNode(this, parent, subpath, environment, initialValue);
+  }
+
+  getValue(node: any): any {
+    // if we ever find a case where scalar nodes can be accessed without iterating through its parent
+    // uncomment this to make sure the parent chain is created when this is accessed
+    // if (node.parent) {
+    //     node.parent.createObservableInstanceIfNeeded()
+    // }
+    const value = node.storedValue;
+    return value instanceof Date ? value : new Date(value);
+  }
+
+  // If the node is a number, return it. If it's a Date, return its timestamp
+  getSnapshot(node: any): any {
+    const value = node.storedValue;
+    return value instanceof Date ? value.getTime() : value;
+  }
+
+  getSubTypes(): null {
+    return null;
+  }
+
+  checker(value: any): boolean {
+    return value instanceof Date || typeof value === "number";
+  }
+
+  isValidSnapshot(value: any, context: any): any {
+    if (this.checker(value as any)) {
+      return typeCheckSuccess();
+    }
+
+    return typeCheckFailure(
+      context,
+      value,
+      `Value is not a Date or a unix milliseconds timestamp`
+    );
+  }
+
+  isAssignableFrom(type: any): boolean {
+    return type === this;
+  }
+
+  validate(value: any, context: any): any {
+    const node = getStateTreeNodeSafe(value);
+    if (node) {
+      const valueType = getType(value);
+      return this.isAssignableFrom(valueType)
+        ? typeCheckSuccess()
+        : typeCheckFailure(context, value);
+      // it is tempting to compare snapshots, but in that case we should always clone on assignments...
+    }
+    return this.isValidSnapshot(value, context);
+  }
+
+  is(thing: any): thing is any {
+    return this.validate(thing, [{ path: "", type: this }]).length === 0;
+  }
+}

--- a/src/t.test.ts
+++ b/src/t.test.ts
@@ -976,4 +976,361 @@ describe("t", () => {
       });
     });
   });
+
+  describe("t.Date", () => {
+    describe("methods", () => {
+      describe("create", () => {
+        describe("with no arguments", () => {
+          if (process.env.NODE_ENV !== "production") {
+            it("should throw an error in development", () => {
+              expect(() => {
+                t.Date.create();
+              }).toThrow();
+            });
+          }
+        });
+        describe("with a number argument", () => {
+          it("should return a Date object", () => {
+            const d = t.Date.create(1701369873059);
+            expect(d instanceof Date).toBe(true);
+          });
+        });
+        describe("with a Date argument", () => {
+          it("should return a Date object", () => {
+            const input = new Date();
+            const d = t.Date.create(input);
+            expect(d instanceof Date).toBe(true);
+          });
+        });
+      });
+      describe("with argument of different types", () => {
+        const testCases = [
+          null,
+          undefined,
+          true,
+          [],
+          function () {},
+          "2022-01-01T00:00:00.000Z",
+          /a/,
+          new Map(),
+          new Set(),
+          Symbol(),
+          new Error(),
+        ];
+
+        if (process.env.NODE_ENV !== "production") {
+          testCases.forEach((testCase) => {
+            it(`should throw an error when passed ${JSON.stringify(
+              testCase
+            )}`, () => {
+              expect(() => {
+                t.Date.create(testCase as any);
+              }).toThrow();
+            });
+          });
+        }
+      });
+    });
+    describe("describe", () => {
+      it("should return the value 'Date'", () => {
+        const description = t.Date.describe();
+        expect(description).toBe("Date");
+      });
+    });
+    describe("getSnapshot", () => {
+      it("should return a number from a date", () => {
+        const date = new Date("2022-01-01T00:00:00.000Z");
+        const d = t.Date.instantiate(null, "", {}, date);
+        const snapshot = t.Date.getSnapshot(d);
+        expect(snapshot).toBe(1640995200000);
+      });
+      it("should return a number from a number", () => {
+        const d = t.Date.instantiate(null, "", {}, 1701369873059);
+        const snapshot = t.Date.getSnapshot(d);
+        expect(snapshot).toBe(1701369873059);
+      });
+    });
+    describe("getSubtype", () => {
+      it("should return null", () => {
+        const subtype = t.Date.getSubTypes();
+        expect(subtype).toBe(null);
+      });
+    });
+    describe("instantiate", () => {
+      if (process.env.NODE_ENV !== "production") {
+        describe("with invalid arguments", () => {
+          it("should not throw an error", () => {
+            expect(() => {
+              // @ts-ignore
+              t.Date.instantiate();
+            }).not.toThrow();
+          });
+        });
+      }
+      describe("with a Date argument", () => {
+        it("should return an object", () => {
+          const s = t.Date.instantiate(null, "", {}, new Date());
+          expect(typeof s).toBe("object");
+        });
+      });
+      describe("with a number argument", () => {
+        it("should return an object", () => {
+          const s = t.Date.instantiate(null, "", {}, 1701369873059);
+          expect(typeof s).toBe("object");
+        });
+      });
+    });
+    describe("is", () => {
+      describe("with a Date argument", () => {
+        it("should return true", () => {
+          const result = t.Date.is(new Date());
+          expect(result).toBe(true);
+        });
+      });
+      describe("with a number argument", () => {
+        it("should return true", () => {
+          const result = t.Date.is(1701369873059);
+          expect(result).toBe(true);
+        });
+      });
+      describe("with argument of different types", () => {
+        const testCases = [
+          null,
+          undefined,
+          true,
+          [],
+          function () {},
+          "2022-01-01T00:00:00.000Z",
+          /a/,
+          new Map(),
+          new Set(),
+          Symbol(),
+          new Error(),
+        ];
+
+        testCases.forEach((testCase) => {
+          it(`should return false when passed ${JSON.stringify(
+            testCase
+          )}`, () => {
+            const result = t.Date.is(testCase as any);
+            expect(result).toBe(false);
+          });
+        });
+      });
+    });
+    describe("isAssignableFrom", () => {
+      describe("with a Date argument", () => {
+        it("should return true", () => {
+          const result = t.Date.isAssignableFrom(t.Date);
+          expect(result).toBe(true);
+        });
+      });
+      describe("with argument of different types", () => {
+        const testCases = [
+          t.string,
+          t.boolean,
+          t.finite,
+          t.float,
+          t.identifier,
+          t.identifierNumber,
+          t.integer,
+          t.null,
+          t.number,
+          t.undefined,
+        ];
+
+        testCases.forEach((testCase) => {
+          it(`should return false when passed ${JSON.stringify(
+            testCase
+          )}`, () => {
+            const result = t.Date.isAssignableFrom(testCase as any);
+            expect(result).toBe(false);
+          });
+        });
+      });
+
+      // TODO: we need to test this, but to be honest I'm not sure what the expected behavior is on single date nodes.
+      describe.skip("reconcile", () => {});
+      describe("validate", () => {
+        describe("with a Date argument", () => {
+          it("should return with no validation errors", () => {
+            const result = t.Date.validate(new Date(), []);
+            expect(result).toEqual([]);
+          });
+        });
+        describe("with a number argument", () => {
+          it("should return with no validation errors", () => {
+            const result = t.Date.validate(1701369873059, []);
+            expect(result).toEqual([]);
+          });
+        });
+        describe("with argument of different types", () => {
+          const testCases = [
+            null,
+            undefined,
+            "2022-01-01T00:00:00.000Z",
+            true,
+            [],
+            function () {},
+            /a/,
+            new Map(),
+            new Set(),
+            Symbol(),
+            new Error(),
+          ];
+
+          testCases.forEach((testCase) => {
+            it(`should return with a validation error when passed ${JSON.stringify(
+              testCase
+            )}`, () => {
+              const result = t.Date.validate(testCase as any, []);
+              expect(result).toEqual([
+                {
+                  context: [],
+                  message:
+                    "Value is not a Date or a unix milliseconds timestamp",
+                  value: testCase,
+                },
+              ]);
+            });
+          });
+        });
+      });
+    });
+    describe("properties", () => {
+      describe("flags", () => {
+        test("return the correct value", () => {
+          const flags = t.Date.flags;
+          expect(flags).toBe(8);
+        });
+      });
+
+      describe("identifierAttribute", () => {
+        // We don't have a way to set the identifierAttribute on a primitive type, so this should return undefined.
+        test("returns undefined", () => {
+          const identifierAttribute = t.Date.identifierAttribute;
+          expect(identifierAttribute).toBe(undefined);
+        });
+      });
+      describe("isType", () => {
+        test("returns true", () => {
+          const isType = t.Date.isType;
+          expect(isType).toBe(true);
+        });
+      });
+      describe("name", () => {
+        test('returns "Date"', () => {
+          const name = t.Date.name;
+          expect(name).toBe("Date");
+        });
+      });
+    });
+    describe("instance", () => {
+      describe("methods", () => {
+        describe("aboutToDie", () => {
+          it("calls the beforeDetach hook", () => {
+            const d = t.Date.instantiate(null, "", {}, new Date());
+            let called = false;
+            d.registerHook(Hook.beforeDestroy, () => {
+              called = true;
+            });
+            d.aboutToDie();
+            expect(called).toBe(true);
+          });
+        });
+        describe("die", () => {
+          it("kills the node", () => {
+            const d = t.Date.instantiate(null, "", {}, new Date());
+            d.die();
+            expect(d.isAlive).toBe(false);
+          });
+          it("should mark the node as dead", () => {
+            const d = t.Date.instantiate(null, "", {}, new Date());
+            d.die();
+            expect(d.state).toBe(NodeLifeCycle.DEAD);
+          });
+        });
+        describe("finalizeCreation", () => {
+          it("should mark the node as finalized", () => {
+            const d = t.Date.instantiate(null, "", {}, new Date());
+            d.finalizeCreation();
+            expect(d.state).toBe(NodeLifeCycle.FINALIZED);
+          });
+        });
+        describe("finalizeDeath", () => {
+          it("should mark the node as dead", () => {
+            const d = t.Date.instantiate(null, "", {}, new Date());
+            d.finalizeDeath();
+            expect(d.state).toBe(NodeLifeCycle.DEAD);
+          });
+        });
+        describe("getReconciliationType", () => {
+          it("should return the correct type", () => {
+            const d = t.Date.instantiate(null, "", {}, new Date());
+            const type = d.getReconciliationType();
+            expect(type).toBe(t.Date);
+          });
+        });
+        describe("getSnapshot", () => {
+          it("should return the value passed in with a number", () => {
+            const d = t.Date.instantiate(null, "", {}, 1701373349399);
+            const snapshot = d.getSnapshot();
+            expect(snapshot).toBe(1701373349399);
+          });
+
+          it("should return the correct date getTime value with a date object", () => {
+            const date = new Date("2022-01-01T00:00:00.000Z");
+            const d = t.Date.instantiate(null, "", {}, date);
+            const snapshot = d.getSnapshot();
+            const expected = date.getTime();
+            expect(snapshot).toBe(expected);
+          });
+        });
+        describe("registerHook", () => {
+          it("should register a hook and call it", () => {
+            const d = t.Date.instantiate(null, "", {}, new Date());
+            let called = false;
+            d.registerHook(Hook.beforeDestroy, () => {
+              called = true;
+            });
+
+            d.die();
+
+            expect(called).toBe(true);
+          });
+        });
+        describe("setParent", () => {
+          if (process.env.NODE_ENV !== "production") {
+            describe("with null", () => {
+              it("should throw an error", () => {
+                const d = t.Date.instantiate(null, "", {}, new Date());
+                expect(() => {
+                  d.setParent(null, "foo");
+                }).toThrow();
+              });
+            });
+            describe.skip("with a parent object", () => {
+              it("should throw an error", () => {
+                const Parent = t.model({
+                  child: t.Date,
+                });
+
+                // @ts-ignore
+                const parent = Parent.create({ child: new Date() });
+
+                const d = t.Date.instantiate(null, "", {}, new Date());
+
+                expect(() => {
+                  // @ts-ignore
+                  d.setParent(parent, "bar");
+                }).toThrow(
+                  "[mobx-state-tree] assertion failed: scalar nodes cannot change their parent"
+                );
+              });
+            });
+          }
+        });
+      });
+    });
+  });
 });

--- a/src/t.ts
+++ b/src/t.ts
@@ -2,12 +2,15 @@ import { model } from "./model";
 import { StringPrimitive } from "./StringPrimitive";
 import { NumberPrimitive } from "./NumberPrimitive";
 import { BooleanPrimitive } from "./BooleanPrimitive";
+import { DatePrimitive } from "./DatePrimitive";
 
 const string: any = new StringPrimitive();
 
 const number: any = new NumberPrimitive();
 
 const boolean: any = new BooleanPrimitive();
+
+const Date: any = new DatePrimitive();
 
 export const getSnapshot = (target: any) => {
   return target.snapshot();
@@ -16,7 +19,7 @@ export const getSnapshot = (target: any) => {
 export const t = {
   model,
   string,
-  Date: null,
+  Date,
   boolean,
   finite: null,
   float: null,


### PR DESCRIPTION
This PR adds `t.Date`, and passes all of the unit tests for MobX-State-Tree `types.Date`.

I think this PR adds the last primitive type that we need before finding a good Primitive abstraction, so we should be able to clean up some of this code.

Once these four primitives are usable and cleaned up, we'll move on to `t.model`, which should be the minimally-useful set of functionality for the library in terms of actually maintaining, modifying, and observing state.